### PR TITLE
faet(fronten): add LEGO colors pallete library/-m- created lib/pallet…

### DIFF
--- a/brixel_app_frontend/src/lib/pallete.js
+++ b/brixel_app_frontend/src/lib/pallete.js
@@ -1,0 +1,49 @@
+let colors = {
+    black: [5, 19, 29],
+    blue: [0, 85, 191],
+    bright_green: [75, 159, 74],
+    bright_light_orange: [248, 187, 61],
+    bright_light_yellow: [255, 240, 58],
+    bright_pink: [228, 173, 200],
+    brown: [88, 57, 39],
+    dark_blue: [10, 52, 99],
+    dark_bluish_gray: [108, 110, 104],
+    dark_gray: [109, 110, 92],
+    dark_orange: [169, 85, 0],
+    dark_pink: [200, 112, 160],
+    dark_purple: [63, 54, 145],
+    dark_red: [114, 14, 15],
+    dark_tan: [149, 138, 115],
+    dark_turquoise: [0, 143, 155],
+    green: [35, 120, 65],
+    light_aqua: [173, 195, 192],
+    light_bluish_gray: [160, 165, 169],
+    light_gray: [155, 161, 157],
+    lime: [187, 233, 11],
+    magenta: [146, 57, 120],
+    medium_azure: [54, 174, 191],
+    olive_green: [155, 154, 90],
+    orange: [254, 138, 24],
+    red: [201, 26, 9],
+    reddish_brown: [88, 42, 18],
+    sand_blue: [96, 116, 161],
+    sand_green: [160, 188, 172],
+    tan: [228, 205, 158],
+    white: [255, 255, 255],
+    yellow: [242, 205, 55],
+    yellowish_green: [223, 238, 165],
+    flat_silver: [137, 135, 136],
+    pearl_gold: [170, 127, 46],
+    metallic_silver: [165, 169, 180],
+
+}
+
+let colors_rgb_arr = [];
+
+for (const value of Object.values(colors)) {
+    colors_rgb_arr.push(value);
+}
+
+
+
+export default colors_rgb_arr;


### PR DESCRIPTION
…e.js with defined LEGO colors in RGB format

- exported colors as an array for further use in image-to-bricks conversion