### PR TITLE
feat(workbench): add clickable canvas for image upload and refactor ImageUploader

### DIFF
--- a/brixel_app_frontend/src/components/ImageUploader/ImageUploader.js
+++ b/brixel_app_frontend/src/components/ImageUploader/ImageUploader.js
@@ -1,28 +1,45 @@
 import { useRef } from "react";
 
 export default function ImageUploader({ onImageLoad }) {
-  const imgRef = useRef(null);
+  const fileInputRef = useRef(null);
 
   const handleFileChange = (e) => {
     const file = e.target.files[0];
     if (!file) return;
 
-    imgRef.current.src = URL.createObjectURL(file);
-    imgRef.current.onload = () => onImageLoad(imgRef.current);
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.src = url;
+    img.onload = () => onImageLoad(img);
+  };
+
+  const handleClick = () => {
+    fileInputRef.current.click();
   };
 
   return (
-    <>
-      <label className="btn btn-secondary mb-3">
-        Select image
-        <input
-          type="file"
-          accept="image/*"
-          onChange={handleFileChange}
-          style={{ display: "none" }}
-        />
-      </label>
-      <img ref={imgRef} alt="source" style={{ display: "none" }} />
-    </>
+    <div
+      onClick={handleClick}
+      style={{
+        cursor: "pointer",
+        border: "2px dashed #aaa",
+        borderRadius: "8px",
+        width: "300px",
+        height: "300px",
+        display: "none",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <span style={{ color: "#777" }}>Click canvas to select image</span>
+
+      <input
+        type="file"
+        accept="image/*"
+        ref={fileInputRef}
+        onChange={handleFileChange}
+        style={{ display: "none" }}
+      />
+    </div>
   );
 }

--- a/brixel_app_frontend/src/components/PixelCanvas/PixelCanvas.js
+++ b/brixel_app_frontend/src/components/PixelCanvas/PixelCanvas.js
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import PixelArtProcessor from "../../lib/pixelArtProcessor";
 
-export default function PixelCanvas({ img, selectedColors, width, height, onCanvasReady }) {
+export default function PixelCanvas({ img, selectedColors, width, height, onCanvasReady, onSelectImage }) {
   const canvasRef = useRef(null);
 
   useEffect(() => {
@@ -20,5 +20,18 @@ export default function PixelCanvas({ img, selectedColors, width, height, onCanv
     if (onCanvasReady) onCanvasReady(canvasRef.current);
   }, [img, selectedColors, width, height, onCanvasReady]);
 
-  return <canvas ref={canvasRef} width={width} height={height}></canvas>;
+  return (
+    <canvas
+      ref={canvasRef}
+      width={width}
+      height={height}
+      onClick={onSelectImage}
+      style={{
+        marginTop: "15px",
+        border: "2px dashed #orange",
+        borderRadius: "8px",
+        cursor: "pointer",
+      }}
+    />
+  );
 }

--- a/brixel_app_frontend/src/components/Workbench/Workbench.js
+++ b/brixel_app_frontend/src/components/Workbench/Workbench.js
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import ImageUploader from "../ImageUploader/ImageUploader";
 import PixelCanvas from "../PixelCanvas/PixelCanvas";
 import PixelDimensions from "../PixelDimensions/PixelDimensions";
 import ColorPalette from "../ColorPalette/ColorPalette";
 import AnalysisTable from "../AnalysisTable/AnalysisTable";
+import styles from './Workbench.module.css'
 
 export default function Workbench({ colors }) {
   const [img, setImg] = useState(null);
@@ -12,6 +13,8 @@ export default function Workbench({ colors }) {
   const [selectedColors, setSelectedColors] = useState([]);
   const [canvas, setCanvas] = useState(null);
   const [analysisResult, setAnalysisResult] = useState(null);
+
+  const fileInputRef = useRef(null);
 
   const handleSavePNG = () => {
     if (!canvas) return;
@@ -36,6 +39,16 @@ export default function Workbench({ colors }) {
       const data = await res.json();
       setAnalysisResult(data);
     }, "image/png");
+  };
+
+    const handleFileChange = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    const url = URL.createObjectURL(file);
+    const image = new Image();
+    image.src = url;
+    image.onload = () => setImg(image);
   };
 
   const handleGeneratePDF = async () => {
@@ -70,17 +83,27 @@ export default function Workbench({ colors }) {
 
   return (
     <div className="workbench d-flex flex-column align-items-center">
-      <ImageUploader onImageLoad={setImg} />
+      <ImageUploader onImageLoad={setImg} style={{ display: "none" }}  />
 
-      <PixelCanvas
+       <PixelCanvas
         img={img}
         selectedColors={selectedColors}
         width={pixelWidth}
         height={pixelHeight}
         onCanvasReady={setCanvas}
+        onSelectImage={() => fileInputRef.current.click()}
+      />
+
+       <input
+        type="file"
+        accept="image/*"
+        ref={fileInputRef}
+        onChange={handleFileChange}
+        style={{ display: "none" }}
       />
 
       <ColorPalette
+        className="colorPallete"
         colors={colors}
         selectedColors={selectedColors}
         onChange={setSelectedColors}

--- a/brixel_app_frontend/src/pages/Workbench.js
+++ b/brixel_app_frontend/src/pages/Workbench.js
@@ -6,7 +6,6 @@ console.log("colors:", colors);
 function WorkbenchPage() {
   return (
     <div>
-      <h1>Workbench Page</h1>
       <Workbench colors={colors} />
     </div>
   );


### PR DESCRIPTION


This update introduces a new way to upload images by clicking directly on the canvas.
- Workbench updated to manage hidden file input via ref
- PixelCanvas now supports onClick handler to trigger image selection
- ImageUploader refactored to integrate with the new workflow This improves UX by making image upload more intuitive and integrated into the canvas.