### PR TITLE
feat(pixelcanvas): add overlay with upload hint and clickable canvas …

### DIFF
--- a/brixel_app_frontend/src/components/PixelCanvas/PixelCanvas.js
+++ b/brixel_app_frontend/src/components/PixelCanvas/PixelCanvas.js
@@ -1,7 +1,15 @@
 import { useEffect, useRef } from "react";
 import PixelArtProcessor from "../../lib/pixelArtProcessor";
+import styles from "./PixelCanvas.module.css";
 
-export default function PixelCanvas({ img, selectedColors, width, height, onCanvasReady, onSelectImage }) {
+export default function PixelCanvas({
+  img,
+  selectedColors,
+  width,
+  height,
+  onCanvasReady,
+  onSelectImage,
+}) {
   const canvasRef = useRef(null);
 
   useEffect(() => {
@@ -21,17 +29,35 @@ export default function PixelCanvas({ img, selectedColors, width, height, onCanv
   }, [img, selectedColors, width, height, onCanvasReady]);
 
   return (
-    <canvas
-      ref={canvasRef}
-      width={width}
-      height={height}
-      onClick={onSelectImage}
-      style={{
-        marginTop: "15px",
-        border: "2px dashed #orange",
-        borderRadius: "8px",
-        cursor: "pointer",
-      }}
-    />
+    <div className={styles.canvasWrapper}>
+      <canvas
+        ref={canvasRef}
+        width={width}
+        height={height}
+        onClick={onSelectImage}
+        className={styles.canvas}
+      />
+
+      {!img && (
+        <div className={styles.overlay}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="36"
+            height="36"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            viewBox="0 0 24 24"
+          >
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="17 8 12 3 7 8" />
+            <line x1="12" y1="3" x2="12" y2="15" />
+          </svg>
+          <span>Click to select an image</span>
+        </div>
+      )}
+    </div>
   );
 }

--- a/brixel_app_frontend/src/components/PixelCanvas/PixelCanvas.module.css
+++ b/brixel_app_frontend/src/components/PixelCanvas/PixelCanvas.module.css
@@ -1,0 +1,27 @@
+.canvasWrapper {
+  position: relative;
+  display: inline-block;
+  margin-top: 15px;
+}
+
+.canvas {
+  border: 2px dashed orange;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.overlay {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: orange;
+  font-size: 16px;
+  font-weight: 500;
+  text-align: center;
+  pointer-events: none; 
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}


### PR DESCRIPTION
…integration

/-mAdded a styled overlay to PixelCanvas with an upload icon and hint text when no image is loaded.
- Introduced PixelCanvas.module.css for styling
- Canvas now shows dashed border and click-to-upload behavior
- Overlay provides a clear call-to-action to improve user experience This update makes the image upload flow more intuitive and visually engaging.